### PR TITLE
[metype-1478] - add is_page_author attribute in comments response

### DIFF
--- a/source/includes/metype/_page_metadata_script.md
+++ b/source/includes/metype/_page_metadata_script.md
@@ -15,12 +15,12 @@ Use this script when you want to save some details of a page that you might want
           });
 ```
 
-`pageMetadata` must be a single level javascript object. The values can be of type String, Number, Array. It can not be a nested object.
+`pageMetadata` must be a single level javascript object. The values can be of type String, Number, Array. You need to add `author_ids` in page metadata if you want to use `respond as author` feature. It can not be a nested object.
 
 Some examples of valid metadata objects are:
 
-* { section: ["science", "tech"], author_id: 123 }
+* { section: ["science", "tech"], author_ids: ["123", "456"] }
 
 * { section: "cooking", top: "true" }
 
-
+* { section: ["science", "tech"], author_ids: ["123"] }

--- a/source/includes/metype/_public_api_documentation.md
+++ b/source/includes/metype/_public_api_documentation.md
@@ -112,6 +112,7 @@ This is documents APIs related to comments APIs. It also gives information about
     "hidden": false,
     "deleted": false,
     "realm_comment_count": 126,
+    "is_page_author": false,
     "author": {},
     "mentions": []
   }],
@@ -143,6 +144,7 @@ headline | string | The title of the story of the page which tagged as `og:title
 hidden | bool | `True` when hidden by author of the comment and vice-versa.
 deleted | bool | `True` when deleted by admin/moderator of the account
 realm_comment_count | integer | Number of published comments in a comment_realm.
+is_page_author | boolean | `True` when comment is made by page author and vice-versa.
 author | object | Contents of this are explained [here] (#get-user-info); null when comment is confidential
 mentions | array | Array of users mentioned in the comment. For more info check here.
 total_count | integer | Number of published comments in a page.


### PR DESCRIPTION
 - To use respond as author feature, need to pass page author ids in page metadata
 - `is_page_author` attribute added in comments response